### PR TITLE
chore: roll out pinact for workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
 
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2.2.0
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Run tests
         run: |
           go vet ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,17 +14,17 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
           fetch-depth: 0
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2.2.0
         with:
           go-version: 1.18
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@b953231f81b8dfd023c58e0854a721e35037f28b # v2.9.1
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -7,7 +7,7 @@ jobs:
   tagpr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - uses: Songmu/tagpr@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,4 @@ This project follows the AI-Centered Development workflow defined in the parent 
 2. **Plan first**: Non-trivial changes need an execution plan in `docs/exec-plan/todo/`.
 3. **Log issues**: Unrelated problems found during work go in `docs/issues/`.
 4. **PR for everything**: All changes go through GitHub PR review.
+5. **GitHub Actions pinning**: When editing GitHub Actions workflows or composite actions, use `pinact` to pin or update `uses:` references rather than hand-editing version tags.

--- a/docs/issues/pinact-cannot-pin-tagpr-main.md
+++ b/docs/issues/pinact-cannot-pin-tagpr-main.md
@@ -1,0 +1,22 @@
+# pinact cannot pin `Songmu/tagpr@main`
+
+## Summary
+
+During the `pinact` rollout, `pinact run` failed on this step:
+
+```text
+.github/workflows/tagpr.yml:11
+- uses: Songmu/tagpr@main
+```
+
+`pinact` still pinned the surrounding `actions/checkout` reference in `tagpr.yml` and the supported action references in the other workflow files.
+
+## Impact
+
+- The repository now follows the `pinact` operator path for supported action references.
+- `Songmu/tagpr@main` remains mutable and outside the current rollout's automatic pinning.
+
+## Follow-up
+
+- Confirm whether `Songmu/tagpr` exposes a supported immutable release/tag strategy that `pinact` can manage.
+- If not, decide whether this workflow should keep `@main`, switch to a different supported ref policy, or adopt an explicit exception mechanism.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -2,3 +2,5 @@
 
 Place detailed specifications here.
 Start with `system-overview.md` or similar high-level docs.
+
+- `github-actions-pinning.md`: GitHub Actions の `uses:` 参照を `pinact` で管理する運用契約

--- a/docs/specs/github-actions-pinning.md
+++ b/docs/specs/github-actions-pinning.md
@@ -1,0 +1,10 @@
+# GitHub Actions Pinning
+
+GitHub Actions workflow files and composite actions in this repository must manage `uses:` references through `pinact`.
+
+## Operator Contract
+
+- When editing `.github/workflows/*.yml` or `.github/actions/**`, use `pinact` to pin new `uses:` references and to update existing pinned references.
+- Do not hand-edit floating version tags such as `@v2` when the change is intended to pin or refresh an action dependency; run `pinact` instead and review the resulting diff.
+- It is acceptable to scope a rollout by passing explicit file paths to `pinact run` when only part of the repository should be updated.
+- `.pinact.yaml` is optional and should be added only when explicit file arguments are insufficient to avoid out-of-scope workflow files.


### PR DESCRIPTION
## Plan / Issues

- **Plan**: N/A
- **Issues**: `docs/issues/pinact-cannot-pin-tagpr-main.md` remains open

## Type of Change

- [ ] Project Plan update
- [ ] Execution Plan (new/updated plan)
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation only
- [x] Chore (CI, tooling, deps)

## Human Instructions / Intent

Human instruction: `docs/exec-plan/todo/pinact-rollout.md $execute-task 実行`
### Additional Context from Instructing Human

- This repository is part of the workspace-wide `pinact` rollout.

## Verification

- [x] Tests pass (command: `go test ./...`)
- [ ] Lint passes (command: `N/A`)
- [x] Manual verification (command: `make build`; reviewed `pinact` diffs for workflow files)

## Checklist

- [x] Branch created from latest `origin/main`
- [x] `docs/specs/` updated (Spec-Code Parity) — _if code changed_
- [ ] Plan moved from `todo` to `done` — _if executing a plan_
- [x] Resolved linked local issues from the plan's `Addresses:` line were moved to `docs/issues/done/`, or this PR explains why they remain open
- [x] Workflow-linter warnings reviewed; all `fixable` warnings were resolved or explicitly justified in this PR
- [x] New issues logged in `docs/issues/` — _if discovered during work_
- [ ] No unresolved blockers remain

## Dependencies

N/A

## Reviewer Notes

- `pinact` could not rewrite `Songmu/tagpr@main`; the branch keeps the supported pinning changes and records the follow-up in `docs/issues/pinact-cannot-pin-tagpr-main.md`.

## Links

N/A

## Breaking Changes

N/A
