### PR TITLE
chore: sync slopless workflow hardening

### DIFF
--- a/.github/workflows/slopless.yml
+++ b/.github/workflows/slopless.yml
@@ -15,12 +15,17 @@ jobs:
       issues: write
       pull-requests: write
     env:
+      NODE_VERSION: "22.19"
       SLOPLESS_VERSION: 0.2.10
       SLOPLESS_SHA: c40c40f3127d0c61cbfc1c34cacf0a5f49ed7e26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Fetch PR base branch
         env:
@@ -66,12 +71,15 @@ jobs:
           python3 - "${files[@]}" <<'PY'
           import json
           import os
+          import socket
           import subprocess
           import sys
           import urllib.error
           import urllib.request
           from pathlib import Path
 
+          COMMAND_TIMEOUT_SECONDS = 120
+          HTTP_TIMEOUT_SECONDS = 30
           version = os.environ["SLOPLESS_VERSION"]
           summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
           repo_root = Path.cwd()
@@ -87,68 +95,75 @@ jobs:
               "slopless/gunning-fog": "Keep each sentence to one idea and replace multi-syllable jargon with plainer alternatives when accuracy allows.",
           }
 
-          findings = []
-          linted_files = []
-
-          for raw_path in sys.argv[1:]:
-              path = Path(raw_path)
+          linted_files = [str(Path(raw_path)) for raw_path in sys.argv[1:]]
+          try:
               proc = subprocess.run(
                   [
                       "npx",
                       "--yes",
                       f"--package=slopless@{version}",
                       "slopless",
-                      str(path),
+                      *linted_files,
                   ],
                   capture_output=True,
                   text=True,
+                  timeout=COMMAND_TIMEOUT_SECONDS,
               )
+          except subprocess.TimeoutExpired as exc:
+              raise SystemExit(
+                  f"slopless timed out after {COMMAND_TIMEOUT_SECONDS}s: {exc.cmd}"
+              ) from exc
 
-              stdout = proc.stdout.strip()
-              if not stdout:
-                  if proc.returncode == 0:
-                      linted_files.append(str(path))
-                      continue
-                  if proc.stderr:
-                      sys.stderr.write(proc.stderr)
-                  raise SystemExit(f"slopless returned {proc.returncode} without JSON output for {path}")
+          stdout = proc.stdout.strip()
+          if proc.returncode not in (0, 1):
+              if proc.stderr:
+                  sys.stderr.write(proc.stderr)
+              raise SystemExit(f"slopless returned {proc.returncode} without usable JSON output")
+          if not stdout:
+              if proc.stderr:
+                  sys.stderr.write(proc.stderr)
+              raise SystemExit("slopless returned no JSON output")
 
+          try:
+              records = json.loads(stdout)
+          except json.JSONDecodeError as exc:
+              if proc.stderr:
+                  sys.stderr.write(proc.stderr)
+              raise SystemExit(f"failed to parse slopless JSON: {exc}") from exc
+
+          findings = []
+          for record in records:
+              file_path = Path(record.get("filePath", ""))
               try:
-                  records = json.loads(stdout)
-              except json.JSONDecodeError as exc:
-                  if proc.stderr:
-                      sys.stderr.write(proc.stderr)
-                  raise SystemExit(f"failed to parse slopless JSON for {path}: {exc}") from exc
-
-              linted_files.append(str(path))
-              for record in records:
-                  file_path = Path(record.get("filePath", str(path)))
-                  try:
-                      display_path = str(file_path.resolve().relative_to(repo_root))
-                  except ValueError:
-                      display_path = str(file_path)
-                  for message in record.get("messages", []):
-                      rule = message.get("ruleId", "slopless")
-                      hint = rule_hints.get(
-                          rule,
-                          "Shorten sentences and simplify wording until the prose becomes easier to scan.",
-                      )
-                      findings.append(
-                          {
-                              "file": display_path,
-                              "line": message.get("line", 1),
-                              "column": message.get("column", 1),
-                              "rule": rule,
-                              "message": message.get("message", "slopless finding"),
-                              "hint": hint,
-                          }
-                      )
+                  display_path = str(file_path.resolve().relative_to(repo_root))
+              except ValueError:
+                  display_path = str(file_path)
+              for message in record.get("messages", []):
+                  rule = message.get("ruleId", "slopless")
+                  hint = rule_hints.get(
+                      rule,
+                      "Shorten sentences and simplify wording until the prose becomes easier to scan.",
+                  )
+                  findings.append(
+                      {
+                          "file": display_path,
+                          "line": message.get("line", 1),
+                          "column": message.get("column", 1),
+                          "rule": rule,
+                          "message": message.get("message", "slopless finding"),
+                          "hint": hint,
+                      }
+                  )
 
           def escape_data(value: str) -> str:
               return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
 
           def escape_property(value: str) -> str:
-              return escape_data(value).replace(":", "%3A").replace(",", "%2C")
+              return (
+                  escape_data(value)
+                  .replace(":", "%3A")
+                  .replace(",", "%2C")
+              )
 
           for finding in findings:
               title = finding["rule"]
@@ -204,20 +219,33 @@ jobs:
                   headers["Content-Type"] = "application/json"
                   data = json.dumps(payload).encode("utf-8")
               request = urllib.request.Request(url, data=data, headers=headers, method=method)
-              with urllib.request.urlopen(request) as response:
+              with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
                   body = response.read().decode("utf-8")
               return json.loads(body) if body else {}
+
+          def iter_pr_comments():
+              page = 1
+              while True:
+                  comments_url = (
+                      f"{github_api_url}/repos/{github_repository}/issues/{pr_number}/comments"
+                      f"?per_page=100&page={page}"
+                  )
+                  comments = github_request("GET", comments_url)
+                  if not comments:
+                      return
+                  for comment in comments:
+                      yield comment
+                  if len(comments) < 100:
+                      return
+                  page += 1
 
           def upsert_pr_comment(body: str) -> None:
               if not github_repository or not pr_number:
                   print("Skipping PR comment upsert because repository or PR number is missing.")
                   return
-              comments_url = (
-                  f"{github_api_url}/repos/{github_repository}/issues/{pr_number}/comments?per_page=100"
-              )
+              comments_url = f"{github_api_url}/repos/{github_repository}/issues/{pr_number}/comments"
               try:
-                  comments = github_request("GET", comments_url)
-                  for comment in comments:
+                  for comment in iter_pr_comments():
                       if comment_marker in comment.get("body", ""):
                           update_url = f"{github_api_url}/repos/{github_repository}/issues/comments/{comment['id']}"
                           github_request("PATCH", update_url, {"body": body})
@@ -231,6 +259,8 @@ jobs:
                       f"Skipping PR comment upsert due to GitHub API error {exc.code}: {details}",
                       file=sys.stderr,
                   )
+              except (socket.timeout, TimeoutError, urllib.error.URLError) as exc:
+                  print(f"Skipping PR comment upsert due to GitHub API timeout/error: {exc}", file=sys.stderr)
 
           comment_body = build_comment_body()
 

--- a/.github/workflows/slopless.yml
+++ b/.github/workflows/slopless.yml
@@ -120,24 +120,37 @@ jobs:
                   sys.stderr.write(proc.stderr)
               raise SystemExit(f"slopless returned {proc.returncode} without usable JSON output")
           if not stdout:
-              if proc.stderr:
-                  sys.stderr.write(proc.stderr)
-              raise SystemExit("slopless returned no JSON output")
+              if proc.returncode == 0:
+                  records = []
+                  stdout = ""
+              else:
+                  if proc.stderr:
+                      sys.stderr.write(proc.stderr)
+                  raise SystemExit("slopless returned no JSON output")
+          else:
+              try:
+                  records = json.loads(stdout)
+              except json.JSONDecodeError as exc:
+                  if proc.stderr:
+                      sys.stderr.write(proc.stderr)
+                  raise SystemExit(f"failed to parse slopless JSON: {exc}") from exc
 
-          try:
-              records = json.loads(stdout)
-          except json.JSONDecodeError as exc:
-              if proc.stderr:
-                  sys.stderr.write(proc.stderr)
-              raise SystemExit(f"failed to parse slopless JSON: {exc}") from exc
-
+          unknown_file_label = "(unknown file)"
+          single_file_fallback = linted_files[0] if len(linted_files) == 1 else None
           findings = []
           for record in records:
-              file_path = Path(record.get("filePath", ""))
-              try:
-                  display_path = str(file_path.resolve().relative_to(repo_root))
-              except ValueError:
-                  display_path = str(file_path)
+              raw_file_path = record.get("filePath")
+              if raw_file_path:
+                  file_path = Path(raw_file_path)
+                  try:
+                      display_path = str(file_path.resolve().relative_to(repo_root))
+                  except ValueError:
+                      display_path = str(file_path)
+              elif single_file_fallback:
+                  display_path = single_file_fallback
+              else:
+                  display_path = unknown_file_label
+
               for message in record.get("messages", []):
                   rule = message.get("ruleId", "slopless")
                   hint = rule_hints.get(
@@ -155,6 +168,13 @@ jobs:
                       }
                   )
 
+          for finding in findings:
+              if finding["file"] == unknown_file_label:
+                  print(
+                      f"slopless finding missing filePath; using {unknown_file_label} in summaries/comments",
+                      file=sys.stderr,
+                  )
+
           def escape_data(value: str) -> str:
               return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
 
@@ -167,13 +187,22 @@ jobs:
 
           for finding in findings:
               title = finding["rule"]
+              message = escape_data(f"{finding['message']} Hint: {finding['hint']}")
+              if finding["file"] == unknown_file_label:
+                  print(
+                      "::warning title={title}::{message}".format(
+                          title=escape_property(title),
+                          message=message,
+                      )
+                  )
+                  continue
               print(
                   "::warning file={file},line={line},col={column},title={title}::{message}".format(
                       file=escape_property(finding["file"]),
                       line=finding["line"],
                       column=finding["column"],
                       title=escape_property(title),
-                      message=escape_data(f"{finding['message']} Hint: {finding['hint']}"),
+                      message=message,
                   )
               )
 


### PR DESCRIPTION
## Plan / Issues

- **Plan**: `vibe-coding-workspace/docs/exec-plan/todo/0040-child-repo-slopless-workflow-follow-up-sync.md`
- **Issues**: `vibe-coding-workspace/docs/issues/0024-child-repo-slopless-workflow-follow-up-sync.md`

## Closes

N/A

## Type of Change

- [ ] Project Plan update
- [ ] Execution Plan (new/updated plan)
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation only
- [x] Chore (CI, tooling, deps)

## Human Instructions / Intent

Human instruction: `/execute-task docs/exec-plan/todo/0040-child-repo-slopless-workflow-follow-up-sync.md`
### Additional Context from Instructing Human

- `Same CIをchild reposにも追加してほしい。それぞれPR作成して。CIの結果、出てきたslopless findingsは対処しない。CIそのものが動くかどうかだけ。またchild repoのdocs/specは触らない。.github/workflows/slopless.yml だけ追加すること。`
- Compatibility exception for child repos: this repo does not ship `tools/list-changed-markdown.sh`, so this PR ports the hardened workspace behavior while keeping inline changed-Markdown detection and the existing `**/*.md` trigger scope.

## Verification

- [x] Lint passes (command: `pinact run .github/workflows/slopless.yml`)
- [x] Manual verification
  - `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/slopless.yml"))'`
  - `git diff --check`
- [x] Tests pass (command: `N/A - workflow-only PR`)

## Checklist

- [x] Branch created from latest `origin/main`
- [x] `docs/specs/` updated (Spec-Code Parity) — N/A: workflow-only child-repo sync
- [x] Plan moved from `todo/` to `done/` — N/A: workspace plan remains canonical in `vibe-coding-workspace`
- [x] Resolved linked local issues from the plan's `Addresses:` line were moved to `docs/issues/done/`, or this PR explains why they remain open — N/A: tracked in `vibe-coding-workspace`
- [x] External GitHub issues declared in the plan's `Addresses:` line are linked under `Issues`, and implementation PRs include matching `Closes` entries or explain why they remain open
- [x] Workflow-linter warnings reviewed; all `fixable` warnings were resolved or explicitly justified in this PR
- [x] New issues logged in `docs/issues/` — none
- [x] No unresolved blockers remain

## Dependencies

N/A

## Reviewer Notes

- This rollout intentionally keeps inline Markdown detection and the broader child-repo trigger scope because the workspace helper script and path filters are workspace-specific.
- The hardening changes synced here are Node setup, single-invocation `slopless`, pagination-aware PR comment upsert, and explicit subprocess/GitHub API timeouts.

## Links

N/A

## Breaking Changes

N/A

## Screenshots / Logs

- `pinact run .github/workflows/slopless.yml`
- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/slopless.yml"))'`
- `git diff --check`

## Workflow-Linter Justification

- Pre-existing fixable warning in `envdiff`: active issue file `docs/issues/pinact-cannot-pin-tagpr-main.md` is not part of this workflow-only branch. This PR leaves it unchanged to preserve the requested narrow scope.
